### PR TITLE
Add notes to transaction payload

### DIFF
--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -20,7 +20,7 @@ const createTransaction = (request) => {
   return {
     payee_name: payee || "Unknown",
     amount: transactionAmount,
-    notes: notes,
+    notes: notes || "",
     date: new Date().toISOString().split("T")[0],
     cleared: false,
   };

--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -6,6 +6,7 @@ const transactionSchema = {
         amount: { type: "number", minimum: 0, default: 0 },
         payee: { type: "string", default: "Unknown" },
         account: { type: "string" },
+        notes: { type: "string" }
       },
       required: ["account"],
     },
@@ -13,12 +14,13 @@ const transactionSchema = {
 };
 
 const createTransaction = (request) => {
-  const { payee, amount } = request.body;
+  const { payee, amount, notes } = request.body;
   const transactionAmount = amount !== undefined ? -Math.round(amount * 100) : 0;
 
   return {
     payee_name: payee || "Unknown",
     amount: transactionAmount,
+    notes: notes,
     date: new Date().toISOString().split("T")[0],
     cleared: false,
   };


### PR DESCRIPTION
Both the Tasker and Automate scripts have the option to prefill the notes field.  In both automations, it will be entered into the budget as "Created by Tasker" or "Created by Automate".  Users have the option within the automations to send an empty string or choose a different note to send.  This can make it easier to know which transactions were manually entered and which were automatically entered using actualtap.