### PR TITLE
ignore trailing slashes, because Tasker automatically appends /, causing 404 errors

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,4 @@
-const fastify = require("fastify")({ logger: true });
+const fastify = require("fastify")({ logger: true, ignoreTrailingSlash: true });
 
 // Global authentication hook - registered at root level to apply to all routes
 fastify.addHook("preHandler", async (request, reply) => {


### PR DESCRIPTION
Regardless of the URL put into Tasker for the POST request, it appends a trailing slash, which triggers a "Route POST:/transaction/ not found" 404 error, this is a quick-fix.