### PR TITLE
Fix network-failure for non-encrypted budgets (WIP on #36)

### DIFF
--- a/src/plugins/actualConnector.js
+++ b/src/plugins/actualConnector.js
@@ -54,7 +54,12 @@ const actualConnector = fp(async (fastify, options) => {
               : ""
           } (attempt ${retryCount + 1}/${maxRetries})`
         );
-        await actual.downloadBudget(process.env.ACTUAL_SYNC_ID, { password: process.env.ACTUAL_ENCRYPTION_PASSWORD });
+
+        if (process.env.ACTUAL_ENCRYPTION_PASSWORD) {
+          await actual.downloadBudget(process.env.ACTUAL_SYNC_ID, { password: process.env.ACTUAL_ENCRYPTION_PASSWORD });
+        } else {
+          await actual.downloadBudget(process.env.ACTUAL_SYNC_ID);
+        }
         fastify.log.info("Budget downloaded successfully");
         budgetDownloaded = true;
       } catch (err) {


### PR DESCRIPTION
Only pass password option to downloadBudget when `ACTUAL_ENCRYPTION_PASSWORD` is set. Previously, an empty string was always passed which potentially caused network-failure errors during sync for non-encrypted budgets in v1.0.12+.

WIP to help #36 