### PR TITLE
Strip currency symbols and handle locale decimal separators in amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.34
+
+- Strip currency symbols and handle locale decimal separators in Tap-to-Pay amounts (#90)
+
+
 ## v1.0.33
 
 - Update @actual-app/api from 26.6.0 to 26.7.0

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pino-pretty": "^13.1.3"
   },
   "name": "actualtap",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Automatically create transactions in Actual Budget when you use Tap-to-Pay on a mobile device",
   "main": "index.js",
   "repository": "https://github.com/MattFaz/actualtap",

--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -20,9 +20,29 @@ const transactionSchema = {
   },
 };
 
+// iOS Shortcuts passes the Tap-to-Pay amount as locale-formatted text, so the
+// string may carry a currency symbol and use either "," or "." as the decimal
+// separator (e.g. "£12.34", "12,34", "1.234,56 €")
+const parseAmount = (raw) => {
+  let value = raw.replace(/[^\d.,-]/g, "");
+  const lastComma = value.lastIndexOf(",");
+  const lastDot = value.lastIndexOf(".");
+
+  if (lastComma > -1 && lastDot > -1) {
+    // Both present: the later one is the decimal separator, the other is a thousands separator
+    value =
+      lastComma > lastDot ? value.replace(/\./g, "").replace(",", ".") : value.replace(/,/g, "");
+  } else if (lastComma > -1) {
+    const isDecimalComma = value.indexOf(",") === lastComma && value.length - lastComma - 1 !== 3;
+    value = isDecimalComma ? value.replace(",", ".") : value.replace(/,/g, "");
+  }
+
+  return parseFloat(value);
+};
+
 const createTransaction = (request) => {
   const { payee, amount: rawAmount, notes, type = "payment" } = request.body;
-  const amount = typeof rawAmount === "string" ? parseFloat(rawAmount) : rawAmount;
+  const amount = typeof rawAmount === "string" ? parseAmount(rawAmount) : rawAmount;
   const isDeposit = type === "deposit";
   const transactionAmount = amount !== undefined && !isNaN(amount) ? Math.round(amount * 100) * (isDeposit ? 1 : -1) : 0;
 
@@ -45,7 +65,7 @@ const getAccountId = async (fastify, accountName) => {
 module.exports = async (fastify, opts) => {
   fastify.post("/transaction", transactionSchema, async (request, reply) => {
     request.log.info(`Received transaction request with body: ${JSON.stringify(request.body)}`);
-    
+
     const transaction = createTransaction(request);
     const accountName = request.body.account;
     const { accountId, accounts } = await getAccountId(fastify, accountName);

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -134,6 +134,111 @@ describe("Transaction API", () => {
       createdTransactionIds.push(body.id);
     });
 
+    it("should strip a currency symbol from a string amount", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: "£12.34",
+          payee: "Test Currency Symbol",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.amount, -1234, "Currency symbol should be stripped before parsing");
+      createdTransactionIds.push(body.id);
+    });
+
+    it("should parse a comma decimal separator", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: "12,34",
+          payee: "Test Comma Decimal",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.amount, -1234, "Comma should be treated as the decimal separator");
+      createdTransactionIds.push(body.id);
+    });
+
+    it("should parse a currency symbol with comma decimal separator", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: "€12,34",
+          payee: "Test Euro Comma",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.amount, -1234, "Symbol should be stripped and comma treated as decimal");
+      createdTransactionIds.push(body.id);
+    });
+
+    it("should parse thousands separators with a dot decimal", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: "$1,234.56",
+          payee: "Test Thousands Dot Decimal",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.amount, -123456, "Comma thousands separator should be removed");
+      createdTransactionIds.push(body.id);
+    });
+
+    it("should parse European format with dot thousands and comma decimal", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: "1.234,56 €",
+          payee: "Test European Format",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.amount, -123456, "Dot thousands separator should be removed and comma treated as decimal");
+      createdTransactionIds.push(body.id);
+    });
+
     it("should use default values when optional fields omitted", async () => {
       const response = await app.inject({
         method: "POST",


### PR DESCRIPTION
## Summary
iOS Shortcuts passes the Tap-to-Pay amount as locale-formatted text. The `/transaction` route fed that string straight to `parseFloat`, so:

- `"£12.34"` / `"€12,34"` / `"$1,234.56"` → `NaN` → saved as **$0** (matches the $0.00 reports in #90)
- `"12,34"` (comma decimal locales) → `12`
- `"1.234,56 €"` → `1.234`

This adds a `parseAmount` helper that strips currency symbols/whitespace and resolves `,`/`.` separators:

- Both present → the later one is the decimal separator (`"$1,234.56"` → 1234.56, `"1.234,56 €"` → 1234.56)
- Only a comma → decimal separator, unless followed by exactly 3 digits (thousands): `"12,34"` → 12.34, `"1,234"` → 1234

## Testing
Added 5 test cases covering the formats above (verified failing before the fix). Full suite passes: 25/25 against a live Actual server.

Note: this fixes the wrong-amount/$0 symptom only — the "shortcut encountered a problem" with no request in server logs (also reported in #90) is a client-side iOS Shortcuts failure and isn't addressed by a server change.

Fixes #90