### PR TITLE
Use transaction date from request body instead of always using server date

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Content-Type: application/json
   "account": "Checking",  // Required: Name of the account in Actual Budget
   "amount": 10.50,       // Optional: Transaction amount (defaults to 0), negative value is a deposit
   "payee": "Starbucks",  // Optional: Name of the payee (defaults to "Unknown")
-  "type": "payment"      // Optional: "payment" or "deposit" (defaults to "payment")
+  "type": "payment",     // Optional: "payment" or "deposit" (defaults to "payment")
+  "date": "2026-07-01"   // Optional: Transaction date in YYYY-MM-DD format (defaults to the server's current date)
 }
 ```
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/mfarrell/private/actualtap/node_modules

--- a/src/routes/transaction.js
+++ b/src/routes/transaction.js
@@ -9,6 +9,7 @@ const transactionSchema = {
         payee: { type: "string", default: "Unknown" },
         account: { type: "string" },
         notes: { type: "string" },
+        date: { type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" },
         type: {
           type: "string",
           enum: ["payment", "deposit"],
@@ -20,8 +21,16 @@ const transactionSchema = {
   },
 };
 
+// The schema pattern guarantees YYYY-MM-DD shape; this catches impossible
+// dates like 2026-02-31 that a Date round-trip silently rolls over
+const isValidDate = (dateStr) => {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+};
+
 const createTransaction = (request) => {
-  const { payee, amount: rawAmount, notes, type = "payment" } = request.body;
+  const { payee, amount: rawAmount, notes, date, type = "payment" } = request.body;
   const amount = typeof rawAmount === "string" ? parseFloat(rawAmount) : rawAmount;
   const isDeposit = type === "deposit";
   const transactionAmount = amount !== undefined && !isNaN(amount) ? Math.round(amount * 100) * (isDeposit ? 1 : -1) : 0;
@@ -31,7 +40,7 @@ const createTransaction = (request) => {
     payee_name: payee || "Unknown",
     amount: transactionAmount,
     notes: notes || "",
-    date: new Date().toLocaleDateString('en-CA'),
+    date: date || new Date().toLocaleDateString('en-CA'),
     cleared: false,
   };
 };
@@ -45,7 +54,14 @@ const getAccountId = async (fastify, accountName) => {
 module.exports = async (fastify, opts) => {
   fastify.post("/transaction", transactionSchema, async (request, reply) => {
     request.log.info(`Received transaction request with body: ${JSON.stringify(request.body)}`);
-    
+
+    if (request.body.date && !isValidDate(request.body.date)) {
+      return reply.code(400).send({
+        error: "Invalid date",
+        message: `"${request.body.date}" is not a valid calendar date. Expected format: YYYY-MM-DD`,
+      });
+    }
+
     const transaction = createTransaction(request);
     const accountName = request.body.account;
     const { accountId, accounts } = await getAccountId(fastify, accountName);

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -134,6 +134,49 @@ describe("Transaction API", () => {
       createdTransactionIds.push(body.id);
     });
 
+    it("should use the date provided in the request", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: 3.21,
+          payee: "Test Provided Date",
+          date: "2026-07-01",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.date, "2026-07-01", "Should use the date from the request body");
+      createdTransactionIds.push(body.id);
+    });
+
+    it("should default to the server date when date is omitted", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: 1.23,
+          payee: "Test Default Date",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.date, new Date().toLocaleDateString("en-CA"), "Should default to today's date");
+      createdTransactionIds.push(body.id);
+    });
+
     it("should use default values when optional fields omitted", async () => {
       const response = await app.inject({
         method: "POST",
@@ -228,6 +271,44 @@ describe("Transaction API", () => {
       });
 
       assert.strictEqual(response.statusCode, 400);
+    });
+
+    it("should return 400 when date is malformed", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: 10.00,
+          date: "07/01/2026",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 400);
+    });
+
+    it("should return 400 when date is not a real calendar date", async () => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/transaction",
+        headers: {
+          "x-api-key": app.config.API_KEY,
+          "content-type": "application/json",
+        },
+        payload: {
+          account: testAccount.name,
+          amount: 10.00,
+          date: "2026-02-31",
+        },
+      });
+
+      assert.strictEqual(response.statusCode, 400);
+      const body = JSON.parse(response.body);
+      assert.strictEqual(body.error, "Invalid date");
     });
 
     it("should return 400 when type is invalid", async () => {


### PR DESCRIPTION
## Summary
- Accept an optional `date` field (`YYYY-MM-DD`) on `POST /transaction` and use it for the created transaction, instead of always stamping the server's current date
- Validate the field: a schema pattern rejects malformed strings (e.g. `07/01/2026`) and a real-calendar-date check returns `400 Invalid date` for impossible dates like `2026-02-31`
- Fall back to the server's current date when `date` is omitted, preserving existing behavior
- Document the field in the README request-body example (the Home Assistant example already sent `date`, but it was silently ignored)

This also unblocks #96, which needs client-supplied dates for re-submitted transactions.

Fixes #107

## Testing
- Added 4 integration tests: provided date is honored, omitted date defaults to today, malformed date returns 400, impossible calendar date returns 400
- Full suite run against a real Actual server: 20 tests, 0 failures (test transactions cleaned up)