### PR TITLE
Fix test suite hanging when Actual API init exceeds Fastify plugin timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Strip currency symbols and handle locale decimal separators in Tap-to-Pay amounts (#90)
 - Use the transaction date from the request body when provided, with YYYY-MM-DD validation; defaults to the server's current date when omitted (#107)
+- Fix test suite hanging when Actual API initialization exceeds Fastify's plugin timeout, and fix shutdown cleanup calling a nonexistent API method (#111)
 
 
 ## v1.0.33

--- a/src/plugins/actualConnector.js
+++ b/src/plugins/actualConnector.js
@@ -182,8 +182,8 @@ const actualConnector = fp(async (fastify) => {
   // Cleanup on shutdown
   fastify.addHook("onClose", async () => {
     try {
-      await actual.close();
-      fastify.log.info("Actual API closed");
+      await actual.shutdown();
+      fastify.log.info("Actual API shut down");
     } catch (err) {
       fastify.log.error(`Cleanup error: ${err.message}`);
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,6 +7,7 @@ const fastify = require("fastify");
 async function buildServer() {
   const app = fastify({
     logger: false,
+    pluginTimeout: 120000, // Match src/server.js - Actual API init can exceed Fastify's 10s default
     ajv: {
       customOptions: {
         allowUnionTypes: true,

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -13,13 +13,17 @@ describe("Transaction API", () => {
   });
 
   after(async () => {
+    // If before() failed, app was never assigned - nothing to clean up
+    if (!app) return;
+
     // Cleanup all created transactions
     if (createdTransactionIds.length > 0) {
       await cleanupTransactions(app.actual, testAccount.id, createdTransactionIds);
       console.log(`Cleaned up ${createdTransactionIds.length} test transaction(s)`);
     }
+
+    // app.close() shuts down the Actual API via the connector's onClose hook
     await app.close();
-    await app.actual.shutdown();
   });
 
   describe("Success scenarios", () => {


### PR DESCRIPTION
## Problem

`npm test` (via `local.sh`) hangs indefinitely after the mocked suites finish — `transaction.test.js` never reports and `node --test` never exits.

## Root cause

- The test `buildServer()` used Fastify's default **10s** `pluginTimeout`, while production uses 120s (`src/server.js`). Connector startup against the real Actual server now takes ~10s (budget download alone is ~7s), so `actualConnector` registration intermittently fails with `AVV_ERR_PLUGIN_EXEC_TIMEOUT`.
- When that fired, the in-flight Actual engine wasn't cancelled and kept syncing in the background. `before()` threw before `app` was assigned, so `after()` never called `shutdown()` — the orphaned engine's open handles kept the child process's event loop alive forever, hanging the whole test run.
- Separately, the connector's `onClose` hook called `actual.close()`, **which doesn't exist** in `@actual-app/api` (the method is `shutdown()`) — the error was silently swallowed, so closing the Fastify app never actually tore down the engine.

## Changes

- `test/helpers.js`: set `pluginTimeout: 120000` to match production
- `src/plugins/actualConnector.js`: `onClose` now calls `actual.shutdown()` instead of the nonexistent `actual.close()`
- `test/transaction.test.js`: `after()` returns early if `before()` failed, and relies on `app.close()` for shutdown (avoids double shutdown now that `onClose` works)

## Verification

Full suite run with real server env: 25/25 tests pass, process exits cleanly (exit 0) in ~32s.